### PR TITLE
Fixed bug in global and local subcommands

### DIFF
--- a/libexec/nenv-global
+++ b/libexec/nenv-global
@@ -7,7 +7,7 @@ NODE_VERSION="$1"
 NODE_VERSION_FILE="${NENV_ROOT}/version"
 
 case "$NODE_VERSION" in
-    "" | "-h" | "--help" )
+    "-h" | "--help" )
         echo "usage: nenv "${0/*nenv-/}" COMMAND [arg1 arg2...]" >&2
         exit 1
         ;;

--- a/libexec/nenv-local
+++ b/libexec/nenv-local
@@ -5,7 +5,7 @@ set -e
 NODE_VERSION="$1"
 
 case "$NODE_VERSION" in
-    "" | "-h" | "--help" )
+    "-h" | "--help" )
         echo "usage: nenv "${0/*nenv-/}" [NODE_VERSION|--unset]" >&2
         echo " --unset : Remove a local file." >&2
         exit 1


### PR DESCRIPTION
If global or local was called without additional arguments the usage
message was displayed instead of printing out the current global/local
version.
