### PR TITLE
Sort versions by fields, rather than the whole string.

### DIFF
--- a/libexec/nenv-versions
+++ b/libexec/nenv-versions
@@ -29,7 +29,7 @@ function remote_versions(){
         sed -e 's/node-//' | sed -e 's/v//' | sed '1,4 d')
     local maxline=$(echo "${version_list}" | wc -l)
     local maxline_1=$[$maxline-1]
-    echo "${version_list}" | sed -e "${maxline_1},${maxline} d" | sort | uniq | tail -n 20
+    echo "${version_list}" | sed -e "${maxline_1},${maxline} d" | sort -t. -k 1,1n -k 2,2n -k 3,3n | uniq | tail -n 20
 }
 
 case "$1" in


### PR DESCRIPTION
Without this commit, the sorted list would be:

```
0.1.0
0.10.0
0.2.0
...
0.9.9
```

With this commit, the order is fixed:

```
0.1.0
0.2.0
...
0.9.9
0.10.0
```

It's enough to sort 3 fields now as Node version number has 3 fields.
