### PR TITLE
Support https redirection on nodejs.org

### DIFF
--- a/libexec/nenv-install
+++ b/libexec/nenv-install
@@ -28,12 +28,12 @@ nenv_remote_versions() {
     curl -so - -L -4 https://iojs.org/dist/index.tab \
       | cut -f 1 | tail -n +2 \
     && \
-    curl -so - http://nodejs.org/dist/ \
-      | egrep '<a href="v.*/'          \
-      | egrep -o '"v[^"]+/'            \
-      | tr -d \"/                      \
-      | egrep -o '[^v]+'               \
-      | sort -V
+    curl -so - -L -4 https://nodejs.org/dist/ \
+       | egrep '<a href="v.*/'          \
+       | egrep -o '"v[^"]+/'            \
+       | tr -d \"/                      \
+       | egrep -o '[^v]+'               \
+       | sort -V
 }
 
 nenv_get_kernel_name(){


### PR DESCRIPTION
Apparently, nenv has been broken relatively recently (probably a few months) by nodejs redirecting http: to https: URLs. This effectively makes `nenv install -l` and related commands only see versions in iojs.org.

This makes the curl command in `nenv install` follow redirects in nodejs so that it can see nodejs versions again.