### PR TITLE
Use $BASH_SOURCE instead of NENV_ROOT

### DIFF
--- a/libexec/nenv-install
+++ b/libexec/nenv-install
@@ -15,9 +15,9 @@
 set -e
 [[ -n $NENV_DEBUG ]] && set -x
 
-source "${NENV_ROOT}/lib/nenv-functions"
+source "${BASH_SOURCE%/*}/../lib/nenv-functions"
 
-NODE_BUILD_ROOT="$(absolute_dirname "$0")/.."
+NODE_BUILD_ROOT="${BASH_SOURCE%/*}/.."
 
 nenv_installed(){
     local version="$1"


### PR DESCRIPTION
When discovering the install location, use `BASH_SOURCE` instead of `NENV_ROOT`.

This is important for when `nenv` is installed outside of `NENV_ROOT`.