### PR TITLE
Support leading `v` in version file

### DIFF
--- a/libexec/nenv-version-file-read
+++ b/libexec/nenv-version-file-read
@@ -10,7 +10,7 @@ if [ -e "$VERSION_FILE" ]; then
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
   words=( $(cut -b 1-1024 "$VERSION_FILE") )
-  version="${words[0]}"
+  version="${words[0]#v}"
 
   if [ -n "$version" ]; then
     echo "$version"


### PR DESCRIPTION
Support leading 'v' in the version file, ensuring compatibility with versions such as `v20.14.0` and `v18.20.3`.

## Why?
From: https://github.com/shadowspawn/node-version-usage#suggested-compatible-format
>  Allowing a leading `v` is common and gives nice symmetry with `node --version`
```output
$ node --version
v20.12.0
$ node --version > .node-version
```